### PR TITLE
chore: download agent on build instead of run so it's predictable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,24 @@ Don't forget to update them!
 
 ```bash
 clever env -a proxy set CC_RUN_COMMAND "./redirection-agent/redirectionio-agent --config-file ./agent.yml"
+clever env -a proxy set CC_PRE_BUILD_HOOK "./clevercloud/pre_build_hook.sh"
 clever env -a proxy set CC_PRE_RUN_HOOK "./clevercloud/pre_run_hook.sh"
 clever env -a proxy set PORT "8080"
 clever env -a proxy set RIO_INSTANCE_NAME "CleverCloud"
-clever env -a proxy set RIO_PROJECT_KEY "RIO PROJECT KEY"
-clever env -a proxy set RIO_FORWARD "http://…cleverapps.io/"
 clever env -a proxy set RIO_PRESERVE_HOST "false"
 clever env -a proxy set RIO_ADD_RULE_IDS_HEADER "true"
 clever env -a proxy set RIO_COMPRESS "true"
 clever env -a proxy set RIO_REQUEST_BODY_SIZE_LIMIT "200MB"
 clever env -a proxy set RIO_LOG_LEVEL "info"
+clever env -a proxy set RIO_PROJECT_KEY "RIO PROJECT KEY"
+clever env -a proxy set RIO_FORWARD "http://…cleverapps.io/"
 ```
 
 `RIO_FORWARD` is in `http`! Not `https`. It is mandatory!
 
-The `Pre Run` hook creates the `agent.yml` configuration file and downloads the latest redirectionio binary.
+The `Pre Build` hook downloads the latest redirectionio binary. If you want to force a new version of the agent, force rebuild it.
+
+The `Pre Run` hook creates the `agent.yml` configuration file.
 
 ### Start the proxy
 
@@ -83,5 +86,5 @@ CC_REVERSE_PROXY_IPS=127.0.0.1
 
 ### The app keeps redirecting to the CC domain (like `https://app-xxxxxx-xxxx-308021983139.cleverapps.io`)
 
-Don't forget to uncheck the "Force HTTPS" in your app's Information.  
+Don't forget to uncheck the "Force HTTPS" in your app's Information.
 You can also update it using : `clever config update --disable-force-https`

--- a/clevercloud/pre_build_hook.sh
+++ b/clevercloud/pre_build_hook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+set -o errexit -o nounset -o xtrace
+
+cd $APP_HOME
+wget https://packages.redirection.io/dist/stable/2/any/redirectionio-agent-latest_any_amd64.tar.gz
+tar xvzf redirectionio-agent-latest_any_amd64.tar.gz
+rm -rf redirectionio-agent-latest_any_amd64.tar.gz

--- a/clevercloud/pre_run_hook.sh
+++ b/clevercloud/pre_run_hook.sh
@@ -2,8 +2,4 @@
 set -o errexit -o nounset -o xtrace
 
 cd $APP_HOME
-wget https://packages.redirection.io/dist/stable/2/any/redirectionio-agent-latest_any_amd64.tar.gz
-tar xvzf redirectionio-agent-latest_any_amd64.tar.gz
-rm -rf redirectionio-agent-latest_any_amd64.tar.gz
-
 envsubst < template.agent.yml > agent.yml


### PR DESCRIPTION
Clever Cloud restart a lot applications for various reasons. I see it as a non trivial risk that it can grab a new untested version. I prefer to move the download phase on the pre build hook so it's always the same version that it used all the time. 

To update, just force a rebuild.